### PR TITLE
Adds `fortressone-sv` Build to Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,12 @@
 FROM ubuntu:22.04
 WORKDIR /fortressonesv
 EXPOSE 27500/udp
-ARG FTE_CONFIG=fortressone
+#ARG FTE_CONFIG=fortressone
 RUN apt-get update \
  && apt-get install -y \
     curl \
     gcc \
+    git \
     libgnutls28-dev \
     libpng-dev \
     make \
@@ -20,6 +21,11 @@ RUN cd /fortressonesv/fortress/dats/ \
     --remote-name-all \
     http://github.com/FortressOne/server-qwprogs/releases/latest/download/{qwprogs,csprogs,menu}.dat \
  && cd /fortressonesv/
+RUN git clone https://github.com/fte-team/fteqw.git
+WORKDIR fteqw/engine
+RUN make sv-rel -j$(nproc)
+RUN mv release/fteqw-sv /fortressonesv/fortressone-sv
+WORKDIR /fortressonesv
 ENTRYPOINT ["/fortressonesv/fortressone-sv"]
 CMD ["-ip", "localhost", \
      "+set", "hostname", "FortressOne", \

--- a/README.md
+++ b/README.md
@@ -83,7 +83,6 @@ E.G. To run a server on port 27500, with full set of assets, in quad mode on mba
 
 ### Build fortressonesv
 
-- Compile fortressone-sv from fteqw repo and copy to the root dir
 - Compile pak0.pak from assets repo and copy to fortress/
 
 ```
@@ -98,6 +97,15 @@ docker tag fortressonesv fortressone/fortressonesv:latest
 docker push fortressone/fortressonesv:latest
 ```
 
+### Using `init.sh`
+
+> Change any environment variables before running
+
+**Build**: `./init.sh build`
+
+**Run local server**: `./init.sh run_local`
+
+**Run public server**: `./init.sh run_public`
 
 ## Without Docker
 

--- a/init.sh
+++ b/init.sh
@@ -1,0 +1,49 @@
+#!/bin/bash
+
+IMAGE="fortressonesv:latest"
+PORT="27500"
+IP="localhost"
+HOSTNAME="Local FortressOne Server"
+RCON_PASSWORD="rc0n"
+ADMIN_PASSWORD="4dm1n"
+CONFIG_MODE="fo_pubmode.cfg"
+MAP="2fort5r.bsp"
+SV_PUBLIC=1
+
+build() {
+  docker build . -t $IMAGE
+}
+
+run_local() {
+	SV_PUBLIC=0
+
+  docker run --interactive --tty --init --rm \
+    --publish $PORT:$PORT/udp \
+    --mount type=bind,source="$(pwd)/fortress/",target=/fortressonesv/fortress/assets/ \
+    --mount type=bind,source="$(pwd)",target=/fortressonesv/fortress/demos/ \
+    $IMAGE \
+    -ip $IP \
+    +set hostname "$HOSTNAME" \
+    +set rcon_password $RCON_PASSWORD \
+    +localinfo adminpwd $ADMIN_PASSWORD \
+    +exec $CONFIG_MODE \
+    +map $MAP \
+    +set sv_public $SV_PUBLIC
+}
+
+run_public() {
+  docker run --interactive --tty --init --rm \
+    --publish $PORT:$PORT/udp \
+    --mount type=bind,source="$(pwd)/fortress/",target=/fortressonesv/fortress/assets/ \
+    --mount type=bind,source="$(pwd)",target=/fortressonesv/fortress/demos/ \
+    $IMAGE \
+    -ip $IP \
+    +set hostname "$HOSTNAME" \
+    +set rcon_password $RCON_PASSWORD \
+    +localinfo adminpwd $ADMIN_PASSWORD \
+    +exec $CONFIG_MODE \
+    +map $MAP \
+    +set sv_public $SV_PUBLIC
+}
+
+"$@"


### PR DESCRIPTION
Includes the steps for building the server binary. Also includes a BASH script for abstracting Docker commands.